### PR TITLE
Refactor: Migrate Sass @import to @use

### DIFF
--- a/_sass/_ed.scss
+++ b/_sass/_ed.scss
@@ -1,3 +1,4 @@
+@use "variables" as *;
 /* Ed: the minimal edition theme.
  * ___________________
  * \_   _____/\______ \

--- a/_sass/_fonts.scss
+++ b/_sass/_fonts.scss
@@ -1,4 +1,4 @@
-/* @use "variables" as *; */
+@use "variables" as *;
 
 .wittgenstein-400 {
   font-family: "Wittgenstein", serif;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,0 +1,16 @@
+/* Fonts */
+$main-font: "Wittgenstein", "Noto Serif KR", "Palatino Linotype", "Book Antiqua", Palatino, serif;
+$heading-font: "Wittgenstein", "Noto Sans KR", sans-serif;
+$title-font: "Wittgenstein Thick", "Noto Serif KR", serif;
+$regular-font-size: 1.25em; /* 20px / 16px = 1.25em; support text resizing in all browsers */
+
+
+/*
+  Color
+
+  Make sure to leave color-scheme in `_config.yml` file empty for granular control */
+
+
+$text-color: #454545;
+$heading-color: #404040;
+$link-color: #841212;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -13,23 +13,7 @@ sitemap: false
   Feel free to change!
 */
 
-/* Fonts */
-$main-font: "Wittgenstein", "Noto Serif KR", "Palatino Linotype", "Book Antiqua", Palatino, serif;
-$heading-font: "Wittgenstein", "Noto Sans KR", sans-serif;
-$title-font: "Wittgenstein Thick", "Noto Serif KR", serif;
-$regular-font-size: 1.25em; /* 20px / 16px = 1.25em; support text resizing in all browsers */
-
-
-/*
-  Color
-
-  Make sure to leave color-scheme in `_config.yml` file empty for granular control */
-
-
-$text-color: #454545;
-$heading-color: #404040;
-$link-color: #841212;
-
-@import "ed";
-@import "syntax";
-@import "fonts"; 
+@use "variables" as *; // This makes variables from _variables.scss globally available
+@use "ed";
+@use "syntax";
+@use "fonts";


### PR DESCRIPTION
This commit updates the Sass stylesheets to use the new @use rule instead of the deprecated @import rule.

Changes include:
- Created a new `_sass/_variables.scss` file to store global style variables.
- Updated `assets/css/style.scss` to use `@use` for importing partials and variables.
- Modified `_sass/_ed.scss` and `_sass/_fonts.scss` to consume variables using `@use "variables" as *;`.

This migration addresses the deprecation warning for `@import` and aligns the project with modern Sass practices.